### PR TITLE
Support for tic80pro, also loading from a config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Bundle and run your [TIC-80](https://tic.computer) ES6 JavaScript carts.
 ## Installation
 
 ``` sh
-npm i tic80-js --save
+npm i tic80-js --save-dev
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ npm i tic80-js --save
 
 3. Build and run the game through TIC-80 JS:
     ```
-    tic80-js index.js
+    npx tic80-js index.js
     ```
 
 4. To export the *cart.tic*, press escape to load the console, and use `save`.

--- a/bin/tic80-js.js
+++ b/bin/tic80-js.js
@@ -6,10 +6,10 @@ const TIC80JS = require('..')
 const configFile = path.resolve('tic80jsconf.js'); 
 let config = {};
 if(fs.existsSync(configFile)) {
-	require(configFile);
+	config = require(configFile);
 }
 
-console.log(config);
+console.log('Using defaults from tic80jsconf.js:', config);
 
 require('yargs')
 	.scriptName('tic80-js')

--- a/bin/tic80-js.js
+++ b/bin/tic80-js.js
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 
+const fs = require('fs')
+const path = require('path')
 const TIC80JS = require('..')
+const configFile = path.resolve('tic80jsconf.js'); 
+let config = {};
+if(fs.existsSync(configFile)) {
+	require(configFile);
+}
+
+console.log(config);
 
 require('yargs')
 	.scriptName('tic80-js')
@@ -9,12 +18,15 @@ require('yargs')
 			yargs.positional('input', {
 				describe: 'The input file to build',
 				type: 'string',
-				default: '.'
+				default: config.input || '.'
 			})
 		},
 		async (argv) => {
-			const tic = new TIC80JS(argv.input)
-			await tic.build(argv.compress)
+			config.input = argv.input
+			config.target = argv.target
+			config.compact = argv.compress
+			const tic = new TIC80JS(config)
+			await tic.build()
 			await tic.run()
 		}
 	)
@@ -22,6 +34,12 @@ require('yargs')
 		describe: 'Whether or not to compress the output file.',
 		type: 'boolean',
 		alias: 'c',
-		default: true
+		default: (typeof config.compact !== 'undefined')?config.compact:true
+	})
+	.option('target', {
+		describe: 'Target platform for the output file.',
+		choices: ['tic80', 'tic80pro', 'tic80uwp'],
+		alias: 't',
+		default: config.target || 'tic80'
 	})
 	.argv

--- a/src/TIC80JS.js
+++ b/src/TIC80JS.js
@@ -51,6 +51,10 @@ class TIC80JS {
 			indent: false
 		}
 		output.output = extendShallow({}, defaultOutput, options.output || {})
+
+		// Target
+		output.target = options.target;
+
 		return output
 	}
 

--- a/src/TIC80JS.js
+++ b/src/TIC80JS.js
@@ -13,8 +13,15 @@ const { execSync } = require('child_process')
 const tempWrite = require('temp-write')
 
 class TIC80JS {
-	constructor(input = '.') {
-		this.input = input
+	constructor(conf) {
+		console.log('Requested TIC80JS using:',conf);
+		const defaults = {
+			input: '.',
+			target: 'tic80',
+			compact: true
+		}
+		this.conf = Object.assign({}, defaults, conf);
+		console.log('Created TIC80JS using:',this.conf);
 	}
 
 	constructOptions(options = {}) {
@@ -78,10 +85,74 @@ class TIC80JS {
 		return output
 	}
 
-	async build(compress = true) {
+	cartData(file) {
+		let output = {}
+		let toGrab = ['TILES', 'PALETTE']
+		if (fs.existsSync(file)) {
+			let source = fs.readFileSync(file, 'utf-8');
+			let comments = []
+			try {
+				comments = commentsParser(source);
+			}
+			catch (error) {
+				// Nothing
+			}
+			const states = { OUTSIDE: 1, FIRSTLINE: 2, INBLOCK: 3};
+			let blockType = '', state = states.OUTSIDE;
+			for (let comment of comments) {
+				// TIC-80 PRO Data comments are all single-line comments
+				let line = comment.lines[0];
+				// Look for state changes as we scan through the lines
+				switch (state) {
+					case states.OUTSIDE:
+						// Look for the start of a block
+						for (let grab of toGrab) {
+							if (line.startsWith("<" + grab)) {
+								// We found one - init working variables
+								blockType = grab;
+								output[blockType] = [];
+								// This is the first line - we don't want to process it
+								state = states.FIRSTLINE;
+							}
+						}
+						break;
+
+					case states.FIRSTLINE:
+						// We only have one first line - we are now in the block
+						state = states.INBLOCK;
+						break;
+
+					case states.INBLOCK:
+						// Look for the last line of the block
+						for (let grab of toGrab) {
+							if (line.startsWith("</" + grab)) {
+								// We are on the last line of a block - reset working variables
+								blockType = '';
+								// The next line will be outside this block - we want to start looking for the begining of the next block
+								state = states.OUTSIDE;
+							}
+						}
+						break;
+
+				}
+				// Now act on the current state
+				if(state == states.INBLOCK) {
+					output[blockType].push(line);
+				}
+			}
+		}
+		
+		return output
+	}
+
+	async build() {
 		let options = this.constructOptions({
-			input: this.input
+			input: this.conf.input,
+			target: this.conf.target,
+			output: {compact: this.conf.compact}
 		})
+		console.log('Using options:',options);
+		let compress = options.output.compact
 
 		let inputTest = require.resolve(options.input)
 		let metadata = this.metaData(inputTest)
@@ -90,6 +161,21 @@ class TIC80JS {
 			preamble += `// ${metadataKey}: ${metadata[metadataKey]}\n`
 		}
 		preamble += 'exports=global=module={};'
+
+		// The tic80pro reads most non-js assets from specially formatted comments
+		// If we are building for the tic80pro, make sure we read those and prepare
+		// them to be added to the end of the tic.js file later
+		let assetComments = '\n'
+		if (options.target == 'tic80pro') {
+			let cartData = this.cartData(inputTest)
+			for (let assetBlockKey in cartData) {
+				assetComments += `// <${assetBlockKey}>\n`
+				assetComments += cartData[assetBlockKey].reduce((o,v)=>{return o+=`// ${v}\n`},'');
+				assetComments += `// </${assetBlockKey}>\n\n`
+			}
+		}
+
+		// Configure the plugins that will transpile (and optionally compress) our cart.js
 		options.plugins = [
 			json({
 				compact: compress,
@@ -136,6 +222,23 @@ class TIC80JS {
 				} : false
 			})
 		]
+		if (options.target == 'tic80pro') {
+			options.plugins[options.plugins.length] = 
+				{
+					name: 'wrap-up', // this name will show up in warnings and errors
+					load ( id ) {
+						// just report what files we load
+						console.log("Loaded:",id);
+						return null; // we aren't actually making any changes
+					},
+					writeBundle ( config ) {
+						let fileName = options.output.file;
+						console.log("Appending tic-80 pro assets to:", fileName);
+						fs.writeFileSync(fileName,assetComments,{flag:'a'});
+					}
+				}
+			
+		}
 
 		const bundle = await rollup.rollup(options);
 
@@ -159,8 +262,8 @@ class TIC80JS {
 	async run() {
 		let spritepath = ''
 		const spritePaths = [
-			path.join(this.input, 'sprites.gif'),
-			path.join(path.dirname(this.input), 'sprites.gif'),
+			path.join(this.conf.input, 'sprites.gif'),
+			path.join(path.dirname(this.conf.input), 'sprites.gif'),
 			'sprites.gif'
 		]
 		for (const file of spritePaths) {
@@ -170,21 +273,38 @@ class TIC80JS {
 			}
 		}
 
-		// Prepare the cart output.
-		if (!fs.existsSync('dist/cart.tic')) {
-			fs.writeFileSync('dist/cart.tic', '')
+		let command = ''
+		if (this.conf.target=='tic80pro') {
+			// For Pro, only load the .js file
+			console.log('Launching cart.js directly in tic80pro')
+			command = 'tic80 dist/cart.js'
+		} else {
+			console.log('Launching cart.tic, cart.js, and sprites.gif')
+
+			// Prepare the cart output.
+			if (!fs.existsSync('dist/cart.tic')) {
+				fs.writeFileSync('dist/cart.tic', '')
+			}
+
+			// Construct the command line arguments.
+			//const filePath = tempWrite.sync(this.code)
+			const filePath = 'dist/cart.js'
+			command = 'tic80 dist/cart.tic -code ' + filePath
+			if (spritepath) {
+				command += ' -sprites ' + spritepath
+			}
 		}
 
-		// Construct the command line arguments.
-		//const filePath = tempWrite.sync(this.code)
-		const filePath = 'dist/cart.js'
-		let command = 'tic80 dist/cart.tic -code ' + filePath
-		if (spritepath) {
-			command += ' -sprites ' + spritepath
+		if (this.conf.target != 'tic80uwp') {
+			// Execute TIC-80
+			console.log(command);
+			execSync(command)
+		} else {
+			// Execute TIC-80 UWP
+			// Note: currently this is useless as even once you find the path below the uwp app does not accept any command line arguments
+			command = 'explorer.exe shell:appsfolder\\50446Nesbox.TICcomputer_8y3dwps6jawp4!App'
+			execSync(command)
 		}
-
-		// Execute TIC-80
-		execSync(command)
 	}
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 
 describe('simple', function() {
 	it('builds the correct output', async function() {
-		const tic = new TIC80JS('tests/simple')
+		const tic = new TIC80JS({input:'tests/simple'})
 		const output = await tic.build()
 		const code = fs.readFileSync('dist/cart.js', 'utf8')
 		assert(code.includes('function TIC(){'))

--- a/tic80jsconf.js
+++ b/tic80jsconf.js
@@ -7,7 +7,7 @@ module.exports = {
     * thus the tic80upw option is not useful and may be removed in a future version
     * Default: 'tic80'
     */
-    version:'tic80',
+    target: 'tic80',
     /* compact: try to make the build js as small as possible
     * If true, the source will be compressed, minimized, and have as much whitespace 
     * removed as possible.

--- a/tic80jsconf.js
+++ b/tic80jsconf.js
@@ -1,0 +1,23 @@
+// optional configuration for the tic80js build system
+
+module.exports = {
+    /* target: tic-80 version to use as the build target 
+    * Must be one of: tic80, tic80pro, tic80uwp
+    * Note that tic80uwp doesn't accept command line parameters at this time
+    * thus the tic80upw option is not useful and may be removed in a future version
+    * Default: 'tic80'
+    */
+    version:'tic80',
+    /* compact: try to make the build js as small as possible
+    * If true, the source will be compressed, minimized, and have as much whitespace 
+    * removed as possible.
+    * If false, the source will skip this step resulting in more readable, but much
+    * less space-efficient code
+    * Default: true
+    */ 
+    compact: true,
+    /* input: the file to use as the root of the project to build
+    * Default: '.'
+    */
+    input: 'tests/simple/index.js'
+}


### PR DESCRIPTION
Adds support for the tic80pro by:
* optionally parsing the specially formatted pro comments from index.js
* appending those comments again at the end of the build if the target is tic80pro
* launching cart.js directly if the target is tic80pro
* allowing the default config to be set in a config file