### PR TITLE
Adding support for pro comment blocks: WAVES, SFX, PATTERNS, TRACKS

### DIFF
--- a/src/TIC80JS.js
+++ b/src/TIC80JS.js
@@ -91,7 +91,7 @@ class TIC80JS {
 
 	cartData(file) {
 		let output = {}
-		let toGrab = ['TILES', 'PALETTE', 'WAVES', 'SFX', 'PATTERNS', 'TRACKS']
+		let toGrab = ['TILES', 'SPRITES', 'PALETTE', 'WAVES', 'SFX', 'PATTERNS', 'TRACKS']
 		if (fs.existsSync(file)) {
 			let source = fs.readFileSync(file, 'utf-8');
 			let comments = []

--- a/src/TIC80JS.js
+++ b/src/TIC80JS.js
@@ -91,7 +91,7 @@ class TIC80JS {
 
 	cartData(file) {
 		let output = {}
-		let toGrab = ['TILES', 'PALETTE']
+		let toGrab = ['TILES', 'PALETTE', 'WAVES', 'SFX', 'PATTERNS', 'TRACKS']
 		if (fs.existsSync(file)) {
 			let source = fs.readFileSync(file, 'utf-8');
 			let comments = []


### PR DESCRIPTION
I missed these pro data comment block types earlier because I didn't have any data in those areas of my cart yet, so they weren't showing up in my saves.  Now I do, so here's the code to handle them.